### PR TITLE
calling to_s on the values from LDAP

### DIFF
--- a/lib/adauth/user.rb
+++ b/lib/adauth/user.rb
@@ -81,7 +81,7 @@ module Adauth
                 define_method(k) do
                     if @entry.attribute_names.include?(val)
                         if block.is_a?(Proc)
-                            return block[@entry.send(val).to_s]
+                            return block[@entry.send(val)]
                         else
                             return @entry.send(val).to_s
                         end


### PR DESCRIPTION
I don't feel that to_s should be called on values that I am going to be handling with a block, since it limits my options. My AD setup returns an array around all values and the to_s messes that up. In my block I can join the array of strings to get a single value. Here is an example from my AD. Notice that even :samaccountname=>["tuser"] has the array wrapping it.
# <Adauth::User:0x6cf52528

 @entry=
  #<Net::LDAP::Entry:0x6cf54e68
   @myhash=
    {:dn=>["CN=Test User,OU=Test Policy OU,DC=pennunited,DC=com"],
     :objectclass=>["top", "person", "organizationalPerson", "user"],
     :cn=>["Test User"],
     :sn=>["User"],
     :givenname=>["Test"],
     :distinguishedname=>
      ["CN=Test User,OU=Test Policy OU,DC=pennunited,DC=com"],
     :instancetype=>["4"],
     :whencreated=>["20100205175124.0Z"],
     :whenchanged=>["20120117181218.0Z"],
     :displayname=>["Test User"],
     :usncreated=>["2342854"],
     :memberof=>
      ["CN=TestGroup,OU=PUT Groups,DC=pennunited,DC=com",
       "CN=Tarmac Users,OU=Tarmac,DC=pennunited,DC=com",
       "CN=CR Carbide Sales,OU=Crystal Report Server Groups,DC=pennunited,DC=com",
       "CN=CR Carbide Managers,OU=Crystal Report Server Groups,DC=pennunited,DC=com",
       "CN=CR Human Resources,OU=Crystal Report Server Groups,DC=pennunited,DC=com",
       "CN=Visual Enterprise 652,OU=PUT Groups,DC=pennunited,DC=com"],
     :usnchanged=>["6477109"],
     :name=>["Test User"],
     :objectguid=>["n\x8BCe\x81\xBC\xF5B\x9B\xA4d\xF5\x9CQO\xF7"],
     :useraccountcontrol=>["66048"],
     :badpwdcount=>["0"],
     :codepage=>["0"],
     :countrycode=>["0"],
     :homedirectory=>["\\balian\users$\tuser"],
     :homedrive=>["J:"],
     :badpasswordtime=>["129690528164124290"],
     :lastlogoff=>["0"],
     :lastlogon=>["129690528227718447"],
     :pwdlastset=>["129671575555254327"],
     :primarygroupid=>["513"],
     :userparameters=>
      ["                                                P\a\x1A\b\x01CtxCfgPresent\xE3\x94\xB5\xE6\x94\xB1\xE6\x88\
     :profilepath=>["\\balian\profile$\tuser"],
     :objectsid=>
      ["\x01\x05\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\xC2y\xEF\xE1\x12\x0EGH\x92\xD0\xAC\xB1|\b\x00\x00"],
     :accountexpires=>["9223372036854775807"],
     :logoncount=>["17"],
     :samaccountname=>["tuser"],
     :samaccounttype=>["805306368"],
     :userprincipalname=>["tuser@pennunited.com"],
     :lockouttime=>["0"],
     :objectcategory=>
      ["CN=Person,CN=Schema,CN=Configuration,DC=pennunited,DC=com"],
     :dscorepropagationdata=>
      ["20111213185133.0Z",
       "20111213185133.0Z",
       "20111213185133.0Z",
       "20111213163904.0Z",
       "16010108151056.0Z"],
     :lastlogontimestamp=>["129712975381065575"]}>>
