### PR TITLE
Updates to fix issue with Ruby 1.9

### DIFF
--- a/lib/adauth/user_model.rb
+++ b/lib/adauth/user_model.rb
@@ -68,7 +68,7 @@ module Adauth
         			user.login = adauth_user.login.gsub(/\"|\[|\]/, "")
         			user.group_strings = adauth_user.groups.join(", ")
         			user.ou_strings = adauth_user.ous.join(", ")
-        			user.name = adauth_user.name(/\"|\[|\]/, "")
+        			user.name = adauth_user.name.gsub(/\"|\[|\]/, "")
         		end
         	end 
         end


### PR DESCRIPTION
I added 4 gsubs to remove the [""] around full_name and login. In Ruby 1.8 this wasnt an issue, but it is in Ruby 1.9.
