### PR TITLE
Changing second gsub to prepend

### DIFF
--- a/lib/adauth/config.rb
+++ b/lib/adauth/config.rb
@@ -19,7 +19,7 @@ module Adauth
         def domain=(s)
             @domain = s
             @server ||= s
-            @base ||= s.gsub(/\./,', dc=').gsub(/^/,"dc=")
+            @base ||= s.gsub(/\./,', dc=').prepend('dc=')
         end
     end
 end


### PR DESCRIPTION
Using `prepend` in `Adauth::Config::domain` instead of the second `gsub` for clarity.
