### PR TITLE
Fix a nil check issue with empty groups

### DIFF
--- a/lib/adauth/ad_objects/group.rb
+++ b/lib/adauth/ad_objects/group.rb
@@ -48,7 +48,11 @@ module Adauth
             end
             
             def cn_groups
-              memberof.split(/.*?CN=(.*?),.*/)
+              if memberof.nil?
+                []
+              else
+                memberof.split(/.*?CN=(.*?),.*/)
+              end
             end
         end
     end


### PR DESCRIPTION
We're hitting an issue where some groups have a `nil` `memberof`. I don't really know why our AD tree is like that, but it causes the `split` in `cn_groups` to blow up. Here's a simple nil check
