### PR TITLE
Fix Handling for Missing LDAP Attributes

### DIFF
--- a/lib/adauth/rails/model_bridge.rb
+++ b/lib/adauth/rails/model_bridge.rb
@@ -34,7 +34,11 @@ module Adauth
                 self.class::AdauthMappings.each do |k, v|
                     setter = "#{k.to_s}=".to_sym
                     value = v.is_a?(Array) ? v.join(", ") : v
-                    self.send(setter, adauth_model.send(value))
+
+                    # ensure the attribute exists in the collected data and only assign if it does
+                    if adauth_model.respond_to?(value)
+                      self.send(setter, adauth_model.send(value))
+                    end
                 end
                 self.save
                 self


### PR DESCRIPTION
Update the code which handles assignment of LDAP attributes to the
actual model to first check whether the targeted attribute exists in the
returned data set from LDAP. Example where this will fail is in the case
where a user specifies they wish to obtain the 'memberof' attributes
from LDAP, but if the account does not belong to any groups, the model
returned will not have a .memberof attribute (and the resulting call
will throw an exception).